### PR TITLE
prevents PHP error when no post is returned

### DIFF
--- a/class-trackserver.php
+++ b/class-trackserver.php
@@ -529,11 +529,12 @@ EOF;
 
 		function detect_shortcode() {
 			global $wp_query;
-			$posts = $wp_query->posts;
+			if ($posts = $wp_query->posts) {
 
-			foreach ( $posts as $post ) {
-				if ( $this->has_shortcode( $post ) ) {
-					return true;
+				foreach ( $posts as $post ) {
+					if ( $this->has_shortcode( $post ) ) {
+						return true;
+					}
 				}
 			}
 			return false;


### PR DESCRIPTION
Prevents PHP Warning: Invalid argument supplied for foreach() in [...]/wp-content/plugins/trackserver/class-trackserver.php on line 534